### PR TITLE
Raise bounds on Cassette & CuArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Yota"
 uuid = "cd998857-8626-517d-b929-70ad188a48f0"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
@@ -16,10 +16,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CUDAapi = "2.0"
-CUDAnative = "2.6"
-CuArrays = "1.5"
-Cassette = "0.2.6"
+CUDAapi = "2.0, 4"
+CUDAnative = "2.6, 3"
+CuArrays = "1.5, 2"
+Cassette = "0.2.6, 0.3"
 Espresso = "0.6.0"
 JuliaInterpreter = "0.7.2"
 julia = "1"


### PR DESCRIPTION
This allows Cassette 0.3 and CuArrays 2, and its friends, after which tests still pass on Julia 1.4. 

Tests still fail on nightly, the message I get is this:
```
grad: basic: Error During Test at /Users/me/.julia/dev/Yota/test/test_grad.jl:8
  Got exception outside of a @test
  TypeError: in new, expected Union{Nothing, Symbol}, got a value of type String
  Stacktrace:
   [1] LineNumberNode(::Int64, ::Any) at ./boot.jl:372
   [2] generate_function_expr(::Tape) at /Users/me/.julia/dev/Yota/src/compile.jl:127
   [3] compile(::Tape; bind::Bool, ret_grad::Bool) at /Users/me/.julia/dev/Yota/src/compile.jl:182
   [4] compile(::Tape) at /Users/me/.julia/dev/Yota/src/compile.jl:182
   [5] compile!(::Tape) at /Users/me/.julia/dev/Yota/src/compile.jl:188
   [6] grad(::Function, ::Array{Float64,2}, ::Vararg{Any,N} where N; dynamic::Bool) at /Users/me/.julia/dev/Yota/src/grad.jl:316
```