### PR TITLE
fix isprimitive bug

### DIFF
--- a/src/cr_api.jl
+++ b/src/cr_api.jl
@@ -11,7 +11,7 @@ import Umlaut: make_name, Input, to_expr, BcastCtx
 struct ChainRulesCtx end
 
 @inline instance_type(f::F) where {F} = F
-@inline instance_type(T::UnionAll) = Type{T}
+@inline instance_type(T::UnionAll) = Type{<:T}
 @inline instance_type(T::DataType) = Type{T}
 
 function isprimitive(::ChainRulesCtx, f, args...)


### PR DESCRIPTION
This PR makes some small changes to `isprimitive` to work around some errors I was seeing on my local machine. Then again, by my understanding the previous code shouldn't work at all. But it clearly passes the existing tests, so at the very least my understanding is incomplete.

The code in the repo contains the call `Core.Compiler.return_type(rrule, (YotaRuleConfig, Ts...,))`. This passes a `Tuple` as the second argument to `return_type`. I've never seen it work this way - it usually requires a `Type{Tuple}`. For example, compare
```julia
julia> Core.Compiler.return_type(+, (Int, Int))
ERROR: MethodError: no method matching return_type(::typeof(+), ::Tuple{DataType, DataType})
Closest candidates are:
  return_type(::Any, ::DataType) at ~/julia/julia-1.8.0-beta1/share/julia/base/compiler/typeinfer.jl:989
  return_type(::Any, ::DataType, ::UInt64) at ~/julia/julia-1.8.0-beta1/share/julia/base/compiler/typeinfer.jl:995
Stacktrace:
 [1] top-level scope
   @ REPL[2]:1

julia> Core.Compiler.return_type(+, Tuple{Int, Int})
Int64
```

The repo code also includes the line
```julia
Ts = [a isa DataType ? Type{a} : typeof(a) for a in (f, args...)]
```

This misses the `UnionAll`  case. For example 
```julia
julia> [a isa DataType ? Type{a} : typeof(a) for a in (Array{Float64},)]
1-element Vector{DataType}:
 UnionAll
```
I assume it's preferred here to return `Type{<:Array{Float64}}`. So this PR works instead in terms of a small helper function `instance_type`, defined as
```julia
@inline instance_type(f::F) where {F} = F
@inline instance_type(T::UnionAll) = Type{<:T}
@inline instance_type(T::DataType) = Type{T}
```