### PR TITLE
Fix rule for `getindex(::Tuple)`

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -26,10 +26,10 @@ function ungetindex(x::AbstractArray, dy, I...)
 end
 
 function ungetindex(x::Tuple, dy, I...)
-    dx = map(1:length(x)) do i
-        i in I ? dy : zero(x[i])
+    dx = ntuple(length(x)) do i
+        i in I ? dy : ZeroTangent()
     end
-    return dx
+    return Tangent{typeof(x)}(dx...)
 end
 
 """

--- a/test/test_grad.jl
+++ b/test/test_grad.jl
@@ -216,6 +216,14 @@ end
     @test g[2] == 2.0
 end
 
+@testset "grad: tuple index" begin
+    y, (_, g) = Yota.grad(x -> x[1].a, ((a=13,), (b=17,)))
+    @test y == 13
+    @test g isa Tangent{<:Tuple}
+    @test g[1] isa Tangent{<:NamedTuple}
+    @test g[1].a == 1
+    @test g[2] isa ZeroTangent
+end
 
 @testset "grad: seed" begin
     val, g = grad(x -> 2x, [1.0, 2.0, 3.0]; seed=ones(3))


### PR DESCRIPTION
This wants to fix the following error:
```
julia> using Flux, Yota

julia> model = Chain(Dense(2=>3, tanh), Dense(3=>2));

julia> Yota.grad((m,x) -> sum(abs2, m(x)), model, randn(Float32, 2, 5))
ERROR: MethodError: no method matching zero(::Dense{typeof(tanh), Matrix{Float32}, Vector{Float32}})
```
After:
```
julia> _, (_, dm, dx) = Yota.grad((m,x) -> sum(abs2, m(x)), model, randn(Float32, 2, 5));

julia> dm.layers[1].bias
3-element Vector{Float32}:
  0.37451237
 -0.008268073
 -0.29834867
```
