### PR TITLE
RFC: don't automatically unthunk grad outputs

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -230,11 +230,8 @@ function finalize_grad!(tape::Tape)
     # add a tuple of (val, (gradients...))
     deriv_vars = [hasderiv(tape, v) ? getderiv(tape, v) : ZeroTangent() for v in inputs(tape)]
     deriv_tuple = push!(tape, mkcall(tuple, deriv_vars...))
-    # unthunk results
-    deriv_tuple_unthunked = push!(tape, mkcall(map, ChainRules.unthunk, deriv_tuple))
-    new_result = push!(tape, mkcall(tuple, tape.result, deriv_tuple_unthunked))
     # set result
-    tape.result = new_result
+    tape.result = deriv_tuple
 end
 
 


### PR DESCRIPTION
This is the other change I made while optimizing https://github.com/jeremiedb/ADTests.jl/blob/main/experiments/yota/dense.jl. By not unthunking all outputs by default, we avoid materializing the gradient of the input `x`. This saves both a significant amount of compute and memory. It's also highly breaking, hence the draft PR. Would there be any interest in having this as an option in `grad` or lower level API? 